### PR TITLE
Update to libmseed version `3.0.17`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-libmseed-sys = { path = "libmseed-sys", version="0.1.2"}
+libmseed-sys = { path = "libmseed-sys", version="0.2.0"}
 
 bitflags = "2.2.1"
 num-traits = "0.2"

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Please refer to the libraries' [examples](examples/).
 
 ## Version of libmseed
 
-Currently this library requires `libmseed` version 3.0.15 (or newer patch
+Currently this library requires `libmseed` version 3.0.17 (or newer patch
 versions). The source for `libmseed` is included in the `libmseed-sys` crate so
 there's no need to pre-install the `libmseed` library, the `libmseed-sys` crate
 will figure that and/or build that for you.

--- a/README.md
+++ b/README.md
@@ -25,13 +25,6 @@ For the crate's documentation please refer to
 
 Please refer to the libraries' [examples](examples/).
 
-## Version of libmseed
-
-Currently this library requires `libmseed` version 3.0.17 (or newer patch
-versions). The source for `libmseed` is included in the `libmseed-sys` crate so
-there's no need to pre-install the `libmseed` library, the `libmseed-sys` crate
-will figure that and/or build that for you.
-
 ## Building mseed
 
 ```sh
@@ -39,6 +32,13 @@ git clone https://github.com/damb/mseed
 cd mseed
 cargo build
 ```
+
+## Version of libmseed
+
+Currently this library requires `libmseed` version 3.0.17 (or newer patch
+versions). The source for `libmseed` is included in the `libmseed-sys` crate so
+there's no need to pre-install the `libmseed` library, the `libmseed-sys` crate
+will figure that and/or build that for you.
 
 ## Contribute
 

--- a/examples/convert.rs
+++ b/examples/convert.rs
@@ -1,0 +1,158 @@
+//! Convert miniSEED records into specified version format.
+//!
+//! The input may contain miniSEED records of different format versions.
+//!
+//! For further information on how to use this example program, simply invoke:
+//!
+//! ```sh
+//! cargo run --example convert -- --help
+//! ``
+
+use std::cell::RefCell;
+use std::fs::OpenOptions;
+use std::io::{BufWriter, Write};
+use std::path::PathBuf;
+use std::rc::Rc;
+
+use clap::Parser;
+
+use mseed::{MSControlFlags, MSReader, MSSampleType, PackInfo};
+
+const MSEED2_RECORD_LENGTH: i32 = 512;
+
+#[derive(Parser, Debug)]
+#[command(author, version)]
+#[command(about = "Convert miniSEED record version format", long_about = None)]
+struct Args {
+    /// Specify target miniSEED version format.
+    #[arg(short = 'F', long, value_name = "FORMAT", default_value_t = 3)]
+    #[arg(value_parser = clap::value_parser!(u8).range(2..4))]
+    format: u8,
+
+    /// Print basic summary.
+    #[arg(short = 's', long)]
+    basic_summary: bool,
+
+    /// Path to miniSEED input file.
+    ///
+    /// Parsing a byte range is possible with the '@'-syntax, e.g.
+    /// path/to/data.mseed[@[FROM][-TO]]
+    #[arg(value_name = "INFILE[@[FROM][-TO]]")]
+    in_file: PathBuf,
+
+    /// Path to output file.
+    #[arg(value_name = "OUTFILE")]
+    out_file: PathBuf,
+}
+
+fn main() {
+    let args = Args::parse();
+
+    // Create reader
+    let mut reader =
+        MSReader::new_with_flags(args.in_file, MSControlFlags::MSF_PNAMERANGE).unwrap();
+    // Create sink
+    let file = OpenOptions::new()
+        .create(true)
+        .write(true)
+        .open(args.out_file)
+        .unwrap();
+    let writer = Rc::new(RefCell::new(BufWriter::new(file)));
+
+    let mut rec_in_cnt = 0;
+    let mut rec_out_cnt = 0;
+    // Loop over miniSEED records
+    while let Some(msr) = reader.next() {
+        let mut msr = msr.unwrap();
+
+        rec_in_cnt += 1;
+
+        if msr.format_version() == args.format {
+            writer.borrow_mut().write_all(msr.raw().unwrap()).unwrap();
+            rec_out_cnt += 1;
+        } else if msr.format_version() == 2 && args.format == 3 {
+            let mut buf = vec![0; msr.raw().unwrap().len() * 2];
+            let bytes_packed = mseed::repack_mseed3(&msr, &mut buf).unwrap();
+            writer.borrow_mut().write_all(&buf[..bytes_packed]).unwrap();
+            rec_out_cnt += 1;
+        } else {
+            // msr.format_version() == 3 && args.format == 2
+            // requires manual repacking
+            let writer = writer.clone();
+            let record_handler = move |rec: &[u8]| {
+                let _ = writer.borrow_mut().write_all(rec).unwrap();
+            };
+
+            msr.unpack_data().unwrap();
+            let mut pack_info = PackInfo::new(msr.sid().unwrap()).unwrap();
+            pack_info.rec_len = MSEED2_RECORD_LENGTH;
+            pack_info.encoding = msr.encoding().unwrap();
+            let flags = MSControlFlags::MSF_PACKVER2 | MSControlFlags::MSF_FLUSHDATA;
+
+            let num_packed_recs = match msr.sample_type() {
+                MSSampleType::Text => {
+                    let mut data_samples = msr.data_samples::<u8>().unwrap().to_vec();
+                    let (num_packed_recs, _) = mseed::pack_raw(
+                        &mut data_samples,
+                        &msr.start_time().unwrap(),
+                        record_handler,
+                        &pack_info,
+                        flags,
+                    )
+                    .unwrap();
+
+                    num_packed_recs
+                }
+                MSSampleType::Integer32 => {
+                    let mut data_samples = msr.data_samples::<i32>().unwrap().to_vec();
+                    let (num_packed_recs, _) = mseed::pack_raw(
+                        &mut data_samples,
+                        &msr.start_time().unwrap(),
+                        record_handler,
+                        &pack_info,
+                        flags,
+                    )
+                    .unwrap();
+
+                    num_packed_recs
+                }
+                MSSampleType::Float32 => {
+                    let mut data_samples = msr.data_samples::<f32>().unwrap().to_vec();
+                    let (num_packed_recs, _) = mseed::pack_raw(
+                        &mut data_samples,
+                        &msr.start_time().unwrap(),
+                        record_handler,
+                        &pack_info,
+                        flags,
+                    )
+                    .unwrap();
+
+                    num_packed_recs
+                }
+                MSSampleType::Float64 => {
+                    let mut data_samples = msr.data_samples::<f32>().unwrap().to_vec();
+                    let (num_packed_recs, _) = mseed::pack_raw(
+                        &mut data_samples,
+                        &msr.start_time().unwrap(),
+                        record_handler,
+                        &pack_info,
+                        flags,
+                    )
+                    .unwrap();
+
+                    num_packed_recs
+                }
+                _ => 0,
+            };
+
+            rec_out_cnt += num_packed_recs;
+        }
+    }
+
+    if args.basic_summary {
+        println!(
+            "Records (in): {}, Records (out): {}",
+            rec_in_cnt, rec_out_cnt
+        );
+    }
+}

--- a/examples/msv.rs
+++ b/examples/msv.rs
@@ -86,7 +86,7 @@ fn main() {
     let mut reader = MSReader::new_with_flags(args.in_file, flags).unwrap();
     // Loop over miniSEED records
     while let Some(msr) = reader.next() {
-        let mut msr = msr.unwrap();
+        let msr = msr.unwrap();
 
         rec_cnt += 1;
         sample_cnt += msr.sample_cnt();

--- a/examples/pack-rollingbuffer.rs
+++ b/examples/pack-rollingbuffer.rs
@@ -56,23 +56,31 @@ fn main() {
 
         mstl.insert(msr, true).unwrap();
 
-        let (cnt_records, cnt_samples) = mstl
-            .pack(record_handler, &pack_info, MSControlFlags::empty())
-            .unwrap();
+        let (cnt_records, cnt_samples) = mseed::pack_trace_list(
+            &mut mstl,
+            record_handler,
+            &pack_info,
+            MSControlFlags::empty(),
+        )
+        .unwrap();
 
         println!(
-            "mstl.pack() created {} records containing {} samples, totally",
+            "mseed::pack_trace_list() created {} records containing {} samples, totally",
             cnt_records, cnt_samples
         );
     }
 
     // Final call to flush data buffers - now with `MSControlFlags::MSF_FLUSHDATA` enabled
-    let (cnt_records, cnt_samples) = mstl
-        .pack(record_handler, &pack_info, MSControlFlags::MSF_FLUSHDATA)
-        .unwrap();
+    let (cnt_records, cnt_samples) = mseed::pack_trace_list(
+        &mut mstl,
+        record_handler,
+        &pack_info,
+        MSControlFlags::MSF_FLUSHDATA,
+    )
+    .unwrap();
 
     println!(
-        "Final mstl.pack() created {} records containing {} samples, totally",
+        "Final mseed::pack_trace_list() created {} records containing {} samples, totally",
         cnt_records, cnt_samples
     );
 }

--- a/examples/pack.rs
+++ b/examples/pack.rs
@@ -602,12 +602,12 @@ fn main() {
     match args.encoding {
         DataEncoding::Text => {
             pack_info.encoding = MSDataEncoding::Text;
-            mseed::pack(&mut text, &start_time, record_handler, &pack_info, flags)
+            mseed::pack_raw(&mut text, &start_time, record_handler, &pack_info, flags)
         }
         DataEncoding::Integer16 => {
             pack_info.encoding = MSDataEncoding::Integer16;
             // The first 220 samples can be represented in 16-bits
-            mseed::pack(
+            mseed::pack_raw(
                 &mut sine_data_i32[..220],
                 &start_time,
                 record_handler,
@@ -617,7 +617,7 @@ fn main() {
         }
         DataEncoding::Integer32 => {
             pack_info.encoding = MSDataEncoding::Integer32;
-            mseed::pack(
+            mseed::pack_raw(
                 &mut sine_data_i32,
                 &start_time,
                 record_handler,
@@ -627,7 +627,7 @@ fn main() {
         }
         DataEncoding::Float32 => {
             pack_info.encoding = MSDataEncoding::Float32;
-            mseed::pack(
+            mseed::pack_raw(
                 &mut sine_data_f32,
                 &start_time,
                 record_handler,
@@ -637,7 +637,7 @@ fn main() {
         }
         DataEncoding::Float64 => {
             pack_info.encoding = MSDataEncoding::Float64;
-            mseed::pack(
+            mseed::pack_raw(
                 &mut sine_data_f64,
                 &start_time,
                 record_handler,
@@ -647,7 +647,7 @@ fn main() {
         }
         DataEncoding::Steim1 => {
             pack_info.encoding = MSDataEncoding::Steim1;
-            mseed::pack(
+            mseed::pack_raw(
                 &mut sine_data_i32,
                 &start_time,
                 record_handler,
@@ -658,7 +658,7 @@ fn main() {
         DataEncoding::Steim2 => {
             pack_info.encoding = MSDataEncoding::Steim2;
             // Steim-2 can represent all but the last difference
-            mseed::pack(
+            mseed::pack_raw(
                 &mut sine_data_i32[..499],
                 &start_time,
                 record_handler,

--- a/examples/read-buffer.rs
+++ b/examples/read-buffer.rs
@@ -38,7 +38,7 @@ fn main() {
     // Set control flags to validate CRC and unpack data samples
     let flags = MSControlFlags::MSF_VALIDATECRC | MSControlFlags::MSF_UNPACKDATA;
     // Create a `MSTraceList` from a buffer
-    let mstl = MSTraceList::from_buffer(&mut buf, flags).unwrap();
+    let mstl = MSTraceList::from_buffer(&buf, flags).unwrap();
     // Print summary
     print!("{}", mstl.display(MSTimeFormat::IsoMonthDay, 1, 1, 0));
 }

--- a/libmseed-sys/Cargo.toml
+++ b/libmseed-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libmseed-sys"
-version = "0.1.2+3.0.15"
+version = "0.2.0+3.0.17"
 authors = ["Daniel Armbruster <dani.armbruster@gmail.com>, Brian Savage <savage13@gmail.com>"]
 links = "mseed"
 build = "build.rs"

--- a/libmseed-sys/build.rs
+++ b/libmseed-sys/build.rs
@@ -6,25 +6,24 @@ use std::path::PathBuf;
 use bindgen::CargoCallbacks;
 
 const LIB_DIR: &str = "vendor";
-const SOURCE_FILES: [&str; 18] = [
+const SOURCE_FILES: [&str; 17] = [
+    "crc32c.c",
+    "extraheaders.c",
     "fileutils.c",
     "genutils.c",
-    "gswap.c",
-    "msio.c",
+    "gmtime64.c",
+    "logging.c",
     "lookup.c",
-    "yyjson.c",
+    "msio.c",
     "msrutils.c",
-    "extraheaders.c",
     "pack.c",
     "packdata.c",
-    "tracelist.c",
-    "gmtime64.c",
-    "crc32c.c",
     "parseutils.c",
+    "selection.c",
+    "tracelist.c",
     "unpack.c",
     "unpackdata.c",
-    "selection.c",
-    "logging.c",
+    "yyjson.c",
 ];
 
 fn main() {

--- a/src/io.rs
+++ b/src/io.rs
@@ -233,11 +233,11 @@ impl<W: Write> MSWriter<W> {
     ///  case of miniSEED 2, unfilled.
     ///  If `flags` has [`MSControlFlags::MSF_PACKVER2`] set `msr` is packed as miniSEED v2
     ///  regardless of msr's [`MSRecord::format_version`].
-    pub fn write_record(&mut self, msr: &mut MSRecord, flags: MSControlFlags) -> MSResult<c_long> {
+    pub fn write_record(&mut self, msr: &MSRecord, flags: MSControlFlags) -> MSResult<c_long> {
         // XXX(damb): reimplementation of [`raw::msr3_writemseed`]
         unsafe {
             check(raw::msr3_pack(
-                msr.get_raw_mut(),
+                msr.get_raw(),
                 Some(record_handler::<W>),
                 (&mut self.writer) as *mut _ as *mut c_void,
                 ptr::null_mut(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,7 +88,7 @@ use libmseed_sys as raw;
 
 pub use crate::error::MSError;
 pub use crate::io::{ConnectionInfo, IntoConnectionInfo, MSFileParam, MSReader, MSWriter};
-pub use crate::pack::{pack, PackInfo};
+pub use crate::pack::{pack, pack_header2, pack_header3, pack_record, repack_mseed3, PackInfo};
 pub use crate::record::{
     detect, MSDataEncoding, MSRecord, MSSampleType, RecordDetection, RecordDisplay,
 };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,13 +28,13 @@
 //! let mut writer = MSWriter::new(out_file);
 //!
 //! while let Some(msr) = reader.next() {
-//!     let mut msr = msr.unwrap();
+//!     let msr = msr.unwrap();
 //!
 //!     if msr.network().unwrap() == "NET" && msr.station().unwrap() == "STA" {
 //!         // do something with msr
 //!
 //!         writer
-//!             .write_record(&mut msr, MSControlFlags::MSF_FLUSHDATA)
+//!             .write_record(&msr, MSControlFlags::MSF_FLUSHDATA)
 //!             .unwrap();
 //!     }
 //! }
@@ -55,7 +55,7 @@
 //!
 //! use mseed::{self, MSControlFlags, PackInfo};
 //!
-//! let mut pack_info = PackInfo::new("FDSN:XX_TEST__X_Y_Z").unwrap();
+//! let pack_info = PackInfo::new("FDSN:XX_TEST__X_Y_Z").unwrap();
 //!
 //! let file = OpenOptions::new()
 //!     .create(true)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,7 +43,7 @@
 //!
 //! ## Low-level miniSEED record I/O
 //!
-//! Creating miniSEED records from raw data samples is possible using the low-level [`pack()`]
+//! Creating miniSEED records from raw data samples is possible using the low-level [`pack_raw()`]
 //! function:
 //!
 //! ```no_run
@@ -70,7 +70,7 @@
 //!
 //! let mut data_samples: Vec<i32> = (1..100).collect();
 //! let start_time = OffsetDateTime::parse("2012-01-01T00:00:00Z", &Iso8601::DEFAULT).unwrap();
-//! mseed::pack(
+//! mseed::pack_raw(
 //!     &mut data_samples,
 //!     &start_time,
 //!     record_handler,
@@ -89,7 +89,7 @@ use libmseed_sys as raw;
 pub use crate::error::MSError;
 pub use crate::io::{ConnectionInfo, IntoConnectionInfo, MSFileParam, MSReader, MSWriter};
 pub use crate::pack::{
-    pack, pack_header2, pack_header3, pack_record, pack_trace_list, repack_mseed3, PackInfo,
+    pack_header2, pack_header3, pack_raw, pack_record, pack_trace_list, repack_mseed3, PackInfo,
     TlPackInfo,
 };
 pub use crate::record::{

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,13 +88,15 @@ use libmseed_sys as raw;
 
 pub use crate::error::MSError;
 pub use crate::io::{ConnectionInfo, IntoConnectionInfo, MSFileParam, MSReader, MSWriter};
-pub use crate::pack::{pack, pack_header2, pack_header3, pack_record, repack_mseed3, PackInfo};
+pub use crate::pack::{
+    pack, pack_header2, pack_header3, pack_record, pack_trace_list, repack_mseed3, PackInfo,
+    TlPackInfo,
+};
 pub use crate::record::{
     detect, MSDataEncoding, MSRecord, MSSampleType, RecordDetection, RecordDisplay,
 };
 pub use crate::trace::{
     DataSampleType, MSTraceId, MSTraceIdIter, MSTraceList, MSTraceSegment, MSTraceSegmentIter,
-    TlPackInfo,
 };
 pub use crate::util::{seedchan2xchan, xchan2seedchan, MSSubSeconds, MSTimeFormat};
 

--- a/src/pack.rs
+++ b/src/pack.rs
@@ -158,7 +158,7 @@ where
 ///
 /// use mseed::{self, MSControlFlags, PackInfo};
 ///
-/// let mut pack_info = PackInfo::new("FDSN:XX_TEST__X_Y_Z").unwrap();
+/// let pack_info = PackInfo::new("FDSN:XX_TEST__X_Y_Z").unwrap();
 ///
 /// let file = OpenOptions::new()
 ///     .create(true)

--- a/src/pack.rs
+++ b/src/pack.rs
@@ -57,7 +57,7 @@ pub fn pack_trace_list<F>(
     mut record_handler: F,
     info: &TlPackInfo,
     flags: MSControlFlags,
-) -> MSResult<(c_long, c_long)>
+) -> MSResult<(usize, usize)>
 where
     F: FnMut(&[u8]),
 {
@@ -89,7 +89,7 @@ where
         }
     }
 
-    Ok((cnt_records, cnt_samples))
+    Ok((cnt_records as usize, cnt_samples as usize))
 }
 
 /// Struct providing miniSEED record packing information.
@@ -272,7 +272,7 @@ pub fn pack_raw<T, F>(
     mut record_handler: F,
     info: &PackInfo,
     flags: MSControlFlags,
-) -> MSResult<(c_long, c_long)>
+) -> MSResult<(usize, usize)>
 where
     F: FnMut(&[u8]),
 {
@@ -344,7 +344,7 @@ where
         raw::msr3_free((&mut msr) as *mut *mut _);
     }
 
-    Ok((cnt_records.into(), cnt_samples))
+    Ok((cnt_records as usize, cnt_samples as usize))
 }
 
 extern "C" fn rh_wrapper<F>(rec: *mut c_char, rec_len: c_int, out: *mut c_void)
@@ -372,7 +372,7 @@ pub fn pack_record<F>(
     msr: &MSRecord,
     mut record_handler: F,
     flags: MSControlFlags,
-) -> MSResult<(c_long, c_long)>
+) -> MSResult<(usize, usize)>
 where
     F: FnMut(&[u8]),
 {
@@ -390,7 +390,7 @@ where
         ))?
     };
 
-    Ok((cnt_records.into(), cnt_samples))
+    Ok((cnt_records as usize, cnt_samples as usize))
 }
 
 ///  Repack a parsed miniSEED record into a version 3 record.
@@ -400,15 +400,17 @@ where
 ///
 ///  Note that this can be used to efficiently convert format versions or modify header values
 ///  without unpacking the data samples.
+///
+///  # Examples
 #[allow(dead_code)]
-pub fn repack_mseed3(msr: &MSRecord, buf: &mut [u8]) -> MSResult<c_int> {
+pub fn repack_mseed3(msr: &MSRecord, buf: &mut [u8]) -> MSResult<usize> {
     Ok(unsafe {
         check(raw::msr3_repack_mseed3(
             msr.get_raw(),
             buf.as_mut_ptr() as *mut _,
             buf.len() as c_uint,
             0,
-        ))?
+        ))? as usize
     })
 }
 
@@ -416,14 +418,14 @@ pub fn repack_mseed3(msr: &MSRecord, buf: &mut [u8]) -> MSResult<c_int> {
 ///
 /// Returns on success the size of the header (fixed and extra) in bytes.
 #[allow(dead_code)]
-pub fn pack_header3(msr: &MSRecord, buf: &mut [u8]) -> MSResult<c_int> {
+pub fn pack_header3(msr: &MSRecord, buf: &mut [u8]) -> MSResult<usize> {
     Ok(unsafe {
         check(raw::msr3_pack_header3(
             msr.get_raw(),
             buf.as_mut_ptr() as *mut _,
             buf.len() as c_uint,
             0,
-        ))?
+        ))? as usize
     })
 }
 
@@ -431,13 +433,13 @@ pub fn pack_header3(msr: &MSRecord, buf: &mut [u8]) -> MSResult<c_int> {
 ///
 /// Returns on success the size of the header (fixed and blockettes) in bytes.
 #[allow(dead_code)]
-pub fn pack_header2(msr: &MSRecord, buf: &mut [u8]) -> MSResult<c_int> {
+pub fn pack_header2(msr: &MSRecord, buf: &mut [u8]) -> MSResult<usize> {
     Ok(unsafe {
         check(raw::msr3_pack_header2(
             msr.get_raw(),
             buf.as_mut_ptr() as *mut _,
             buf.len() as c_uint,
             0,
-        ))?
+        ))? as usize
     })
 }

--- a/src/pack.rs
+++ b/src/pack.rs
@@ -9,6 +9,7 @@ use crate::{
 use raw::MS3Record;
 
 /// Struct providing miniSEED record packing information.
+#[derive(Debug, Clone)]
 pub struct PackInfo {
     /// FDSN source identifier.
     sid: CString,

--- a/src/pack.rs
+++ b/src/pack.rs
@@ -170,7 +170,7 @@ where
     Ok(sid)
 }
 
-/// Low level function that packs `data_samples` into miniSEED records.
+/// Low level function that packs raw data samples into miniSEED records.
 ///
 /// `start_time` is the time of the first data sample. Buffers containing the packed miniSEED
 /// records are passed to the `record_handler` closure. Returns on success a tuple where the first
@@ -214,7 +214,7 @@ where
 /// let start_time = OffsetDateTime::parse("2012-01-01T00:00:00Z", &Iso8601::DEFAULT).unwrap();
 ///
 /// let mut payload: Vec<u8> = "Hello, miniSEED!".bytes().collect();
-/// let (cnt_records, cnt_samples) = mseed::pack(
+/// let (cnt_records, cnt_samples) = mseed::pack_raw(
 ///     &mut payload,
 ///     &start_time,
 ///     record_handler,
@@ -257,7 +257,7 @@ where
 ///
 /// let mut data_samples: Vec<i32> = (1..100).collect();
 /// let start_time = OffsetDateTime::parse("2012-01-01T00:00:00Z", &Iso8601::DEFAULT).unwrap();
-/// mseed::pack(
+/// mseed::pack_raw(
 ///     &mut data_samples,
 ///     &start_time,
 ///     record_handler,
@@ -266,7 +266,7 @@ where
 /// )
 /// .unwrap();
 /// ```
-pub fn pack<T, F>(
+pub fn pack_raw<T, F>(
     data_samples: &mut [T],
     start_time: &time::OffsetDateTime,
     mut record_handler: F,

--- a/src/trace.rs
+++ b/src/trace.rs
@@ -1,13 +1,11 @@
-use std::ffi::{
-    c_char, c_double, c_float, c_int, c_long, c_uchar, c_uint, c_ulong, c_void, CString,
-};
+use std::ffi::{c_char, c_double, c_float, c_int, c_long, c_uchar, c_uint, c_ulong};
 use std::fmt;
 use std::ptr;
 use std::slice::from_raw_parts;
 
 use crate::{
-    error::check, pack, raw, util, MSControlFlags, MSDataEncoding, MSError, MSRecord, MSResult,
-    MSSampleType, MSSubSeconds, MSTimeFormat,
+    error::check, raw, util, MSControlFlags, MSError, MSRecord, MSResult, MSSampleType,
+    MSSubSeconds, MSTimeFormat,
 };
 use time::OffsetDateTime;
 
@@ -448,61 +446,6 @@ impl MSTraceList {
         Ok(())
     }
 
-    /// Packs the trace lists' data into miniSEED records.
-    ///
-    /// Buffers containing the packed miniSEED records are passed to the `record_handler` closure.
-    /// Returns on success a tuple where the first value is the number of totally packed records
-    /// and the second value is the number of totally packed samples.
-    ///
-    /// Packing is controlled by the following `flags`:
-    /// - If `flags` has [`MSControlFlags::MSF_FLUSHDATA`] set, all of the trace lists' data will be
-    /// packed into miniSEED records even though the last one will probably be smaller than
-    /// requested or, in the case of miniSEED v2, unfilled.
-    /// - If `flags` has [`MSControlFlags::MSF_PACKVER2`] set records are packed as miniSEED v2.
-    /// - If `flags` has [`MSControlFlags::MSF_MAINTAINMSTL`] packed data is not removed from the
-    /// trace lists' internal buffers.
-    ///
-    /// See also [`pack()`] for packing raw data samples.
-    pub fn pack<F>(
-        &mut self,
-        mut record_handler: F,
-        info: &TlPackInfo,
-        flags: MSControlFlags,
-    ) -> MSResult<(c_long, c_long)>
-    where
-        F: FnMut(&[u8]),
-    {
-        let mut extra_ptr = ptr::null_mut();
-        if let Some(extra_headers) = &info.extra_headers {
-            let cloned = extra_headers.clone();
-            extra_ptr = cloned.into_raw();
-        }
-
-        let mut cnt_samples: c_long = 0;
-        let cnt_samples_ptr = &mut cnt_samples as *mut _;
-        let cnt_records = unsafe {
-            check(raw::mstl3_pack(
-                self.inner,
-                Some(pack::rh_wrapper::<F>),
-                (&mut record_handler) as *mut _ as *mut c_void,
-                info.rec_len,
-                info.encoding as c_char,
-                cnt_samples_ptr,
-                flags.bits(),
-                0,
-                extra_ptr,
-            ))?
-        };
-
-        if !extra_ptr.is_null() {
-            unsafe {
-                let _ = CString::from_raw(extra_ptr);
-            }
-        }
-
-        Ok((cnt_records, cnt_samples))
-    }
-
     /// Returns an object that implements [`Display`] for printing a trace list summary.
     ///
     /// By default only prints the FDSN source identifier, starttime and endtime for each
@@ -534,34 +477,6 @@ impl MSTraceList {
 impl Drop for MSTraceList {
     fn drop(&mut self) {
         unsafe { raw::mstl3_free((&mut self.inner) as *mut *mut MS3TraceList, 1) };
-    }
-}
-
-/// Struct aggregating [`MSTraceList`] packing information.
-///
-/// See also [`PackInfo`](crate::PackInfo).
-#[derive(Debug, Clone)]
-pub struct TlPackInfo {
-    // /// The miniSEED format version.
-    // pub format_version: c_uchar,
-    /// Data encoding.
-    pub encoding: MSDataEncoding,
-    /// Record length used for encoding.
-    pub rec_len: c_int,
-    /// Extra headers.
-    ///
-    /// If not `None` it is expected to contain extra headers, i.e. a string containing (compact)
-    /// JSON, that will be added to each output record.
-    pub extra_headers: Option<CString>,
-}
-
-impl Default for TlPackInfo {
-    fn default() -> Self {
-        Self {
-            encoding: MSDataEncoding::Steim2,
-            rec_len: 4096,
-            extra_headers: None,
-        }
     }
 }
 

--- a/src/trace.rs
+++ b/src/trace.rs
@@ -320,7 +320,7 @@ impl<'id> DoubleEndedIterator for MSTraceSegmentIter<'id> {
 /// // read content of `data.mseed` into `buf`
 /// reader.read_to_end(&mut buf).unwrap();
 ///
-/// let mstl = MSTraceList::from_buffer(&mut buf, MSControlFlags::MSF_UNPACKDATA).unwrap();
+/// let mstl = MSTraceList::from_buffer(&buf, MSControlFlags::MSF_UNPACKDATA).unwrap();
 /// ```
 ///
 /// If controlling the records to be inserted is desired, using [`MSReader`] is required:
@@ -385,15 +385,15 @@ impl MSTraceList {
     }
 
     /// Creates a new [`MSTraceList`] from a buffer.
-    pub fn from_buffer(buf: &mut [u8], flags: MSControlFlags) -> MSResult<Self> {
+    pub fn from_buffer(buf: &[u8], flags: MSControlFlags) -> MSResult<Self> {
         let mut rv = Self::new()?;
 
         unsafe {
-            let buf = &mut *(buf as *mut [u8] as *mut [c_char]);
+            let buf = &*(buf as *const [_] as *const [_]);
             check(raw::mstl3_readbuffer(
                 (&mut rv.get_raw_mut()) as *mut *mut _,
-                buf.as_mut().as_mut_ptr(),
-                buf.as_mut().len() as c_ulong,
+                buf.as_ptr(),
+                buf.len() as c_ulong,
                 0,
                 flags.bits(),
                 ptr::null_mut(),


### PR DESCRIPTION
This PR contains several API changes!

**Feature and Changes**:
- Bump libmseed version to `3.0.17` and use non-`mut` references where possible (due to libmseed API changes)
- Implement remaining `pack` facilities
- Rename `pack()` -> `pack_raw()`
- Implement `MSTraceList::pack()` as free function, i.e. `pack_trace_list()`
- Implement version format conversion example tool