### PR TITLE
Adopt to portable C `char` type

### DIFF
--- a/src/record.rs
+++ b/src/record.rs
@@ -50,7 +50,7 @@ pub fn detect<T: AsRef<[u8]>>(buf: T) -> MSResult<RecordDetection> {
 }
 
 /// An enumeration of possible sample types.
-#[repr(i8)]
+#[repr(u8)]
 #[derive(Debug, Eq, PartialEq, Copy, Clone)]
 pub enum MSSampleType {
     /// Unknown data sample type.
@@ -67,7 +67,7 @@ pub enum MSSampleType {
 
 impl MSSampleType {
     /// Creates a `MSSampleType` from the given `ch`.
-    pub fn from_char(ch: c_char) -> Self {
+    pub fn from_char(ch: u8) -> Self {
         match ch {
             116 => Self::Text,      // t
             105 => Self::Integer32, // i
@@ -79,41 +79,41 @@ impl MSSampleType {
 }
 
 /// An enumeration of possible data encodings.
-#[repr(i8)]
+#[repr(u8)]
 #[derive(Debug, Eq, PartialEq, Copy, Clone)]
 pub enum MSDataEncoding {
     /// Text encoding (UTF-8)
-    Text = raw::DE_TEXT as c_char,
+    Text = raw::DE_TEXT as u8,
     /// 16-bit integer encoding
-    Integer16 = raw::DE_INT16 as c_char,
+    Integer16 = raw::DE_INT16 as u8,
     /// 32-bit integer encoding
-    Integer32 = raw::DE_INT32 as c_char,
+    Integer32 = raw::DE_INT32 as u8,
     /// 32-bit floating point encoding (IEEE)
-    Float32 = raw::DE_FLOAT32 as c_char,
+    Float32 = raw::DE_FLOAT32 as u8,
     /// 64-bit floating point encoding (IEEE)
-    Float64 = raw::DE_FLOAT64 as c_char,
+    Float64 = raw::DE_FLOAT64 as u8,
     /// Steim-1 compressed integer encoding
-    Steim1 = raw::DE_STEIM1 as c_char,
+    Steim1 = raw::DE_STEIM1 as u8,
     /// Steim-2 compressed integer encoding
-    Steim2 = raw::DE_STEIM2 as c_char,
+    Steim2 = raw::DE_STEIM2 as u8,
     /// **Legacy**: GEOSCOPE 24-bit integer encoding
-    GeoScope24 = raw::DE_GEOSCOPE24 as c_char,
+    GeoScope24 = raw::DE_GEOSCOPE24 as u8,
     /// **Legacy**: GEOSCOPE 16-bit gain ranged, 3-bit exponent
-    GeoScope163 = raw::DE_GEOSCOPE163 as c_char,
+    GeoScope163 = raw::DE_GEOSCOPE163 as u8,
     /// **Legacy**: GEOSCOPE 16-bit gain ranged, 4-bit exponent
-    GeoScope164 = raw::DE_GEOSCOPE164 as c_char,
+    GeoScope164 = raw::DE_GEOSCOPE164 as u8,
     /// **Legacy**: CDSN 16-bit gain ranged
-    CDSN = raw::DE_CDSN as c_char,
+    CDSN = raw::DE_CDSN as u8,
     /// **Legacy**: SRO 16-bit gain ranged
-    SRO = raw::DE_SRO as c_char,
+    SRO = raw::DE_SRO as u8,
     /// **Legacy**: DWWSSN 16-bit gain ranged
-    DWWSSN = raw::DE_DWWSSN as c_char,
+    DWWSSN = raw::DE_DWWSSN as u8,
 }
 
 impl MSDataEncoding {
     /// Create a `MSDataEncoding` from the given `ch`.
-    pub fn from_char(ch: c_char) -> MSResult<Self> {
-        match ch as c_uint {
+    pub fn from_char(ch: u8) -> MSResult<Self> {
+        match ch as u32 {
             raw::DE_TEXT => Ok(Self::Text),
             raw::DE_INT16 => Ok(Self::Integer16),
             raw::DE_INT32 => Ok(Self::Integer32),
@@ -224,7 +224,7 @@ impl MSRecord {
 
     /// Returns a lossy version of the [FDSN source identifier](https://docs.fdsn.org/projects/source-identifiers/).
     pub fn sid_lossy(&self) -> String {
-        util::i8_to_string(&(self.ptr().sid))
+        util::to_string(&(self.ptr().sid))
     }
 
     /// Returns the network code identifier of the record.
@@ -293,7 +293,7 @@ impl MSRecord {
 
     /// Returns the data encoding format of the record.
     pub fn encoding(&self) -> MSResult<MSDataEncoding> {
-        MSDataEncoding::from_char(self.ptr().encoding)
+        MSDataEncoding::from_char(self.ptr().encoding as _)
     }
 
     /// Returns the record publication version.
@@ -357,12 +357,12 @@ impl MSRecord {
 
     /// Returns the record sample type.
     pub fn sample_type(&self) -> MSSampleType {
-        MSSampleType::from_char(self.ptr().sampletype)
+        MSSampleType::from_char(self.ptr().sampletype as _)
     }
 
     /// Creates a new independently owned [`MSRecord`] from the underlying record.
     pub fn try_clone(&self) -> MSResult<Self> {
-        let rv = unsafe { raw::msr3_duplicate(self.0, true as i8) };
+        let rv = unsafe { raw::msr3_duplicate(self.0, true as _) };
 
         if rv.is_null() {
             return Err(MSError::from_str("failed to duplicate"));

--- a/src/trace.rs
+++ b/src/trace.rs
@@ -156,7 +156,7 @@ impl<'id> MSTraceSegment<'id> {
 
     /// Returns the trace segment sample type.
     pub fn sample_type(&self) -> MSSampleType {
-        MSSampleType::from_char(self.ptr().sampletype)
+        MSSampleType::from_char(self.ptr().sampletype as _)
     }
 
     /// Returns whether the data samples are unpacked.
@@ -208,8 +208,8 @@ impl DataSampleType for c_int {
         let rv = unsafe {
             check(raw::mstl3_convertsamples(
                 seg,
-                MSSampleType::Integer32 as i8,
-                truncate as i8,
+                MSSampleType::Integer32 as _,
+                truncate as _,
             ))
         };
 
@@ -225,8 +225,8 @@ impl DataSampleType for c_float {
         let rv = unsafe {
             check(raw::mstl3_convertsamples(
                 seg,
-                MSSampleType::Float32 as i8,
-                truncate as i8,
+                MSSampleType::Float32 as _,
+                truncate as _,
             ))
         };
 
@@ -242,8 +242,8 @@ impl DataSampleType for c_double {
         let rv = unsafe {
             check(raw::mstl3_convertsamples(
                 seg,
-                MSSampleType::Float64 as i8,
-                truncate as i8,
+                MSSampleType::Float64 as _,
+                truncate as _,
             ))
         };
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -109,8 +109,8 @@ pub fn time_to_nstime(t: &time::OffsetDateTime) -> i64 {
     t.unix_timestamp()
 }
 
-/// Utility function safely converting a slice of `i8` values into a `String`.
-pub(crate) fn i8_to_string(buf: &[i8]) -> String {
+/// Utility function safely converting a slice of `c_char` values into a `String`.
+pub(crate) fn to_string(buf: &[c_char]) -> String {
     let v: Vec<u8> = buf
         .iter()
         .map(|x| *x as u8) // cast i8 as u8
@@ -139,7 +139,7 @@ impl NetStaLocCha {
     pub fn from_sid(sid: &[c_char]) -> MSResult<Self> {
         let s0 = "           ";
         let s1 = "                               ";
-        let sid = CString::new(i8_to_string(sid)).unwrap().into_raw();
+        let sid = CString::new(to_string(sid)).unwrap().into_raw();
         let xnet = CString::new(s0).unwrap().into_raw();
         let xsta = CString::new(s0).unwrap().into_raw();
         let xloc = CString::new(s0).unwrap().into_raw();


### PR DESCRIPTION
Note that the C standard doesn't define explicitly whether the `char` type is `unsigned` or `signed`. E.g. on `arm` a `char` is `unsigned` while on `x86` it is `signed`.

Closes #6.