### PR TITLE
Update types for changes in libmseed v3.0.19

### DIFF
--- a/libmseed-sys/Cargo.toml
+++ b/libmseed-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libmseed-sys"
-version = "0.2.1+3.0.17"
+version = "0.2.1+3.0.19"
 authors = ["Daniel Armbruster <dani.armbruster@gmail.com>, Brian Savage <savage13@gmail.com>"]
 links = "mseed"
 build = "build.rs"

--- a/src/pack.rs
+++ b/src/pack.rs
@@ -1,4 +1,4 @@
-use std::ffi::{c_char, c_double, c_int, c_long, c_uchar, c_uint, c_ushort, c_void, CString};
+use std::ffi::{c_char, c_double, c_int, c_long, c_ulong, c_uchar, c_uint, c_ushort, c_void, CString};
 use std::mem;
 use std::ptr;
 use std::slice;
@@ -320,7 +320,7 @@ where
             .map_err(|e| MSError::from_str(&format!("invalid data sample length ({})", e)))?
             as _;
         (*msr).datasamples = data_samples.as_mut_ptr() as *mut _ as *mut c_void;
-        (*msr).datasize = mem::size_of_val(data_samples);
+        (*msr).datasize = mem::size_of_val(data_samples) as c_ulong;
         (*msr).extralength = 0;
         (*msr).extra = ptr::null_mut();
     }

--- a/src/record.rs
+++ b/src/record.rs
@@ -1,4 +1,4 @@
-use std::ffi::{c_char, c_double, c_long, c_uchar, c_uint, c_ushort, CStr};
+use std::ffi::{c_char, c_double, c_long, c_ulong,c_uchar, c_uint, CStr};
 use std::fmt;
 use std::ptr;
 use std::slice::from_raw_parts;
@@ -331,7 +331,7 @@ impl MSRecord {
     }
 
     /// Returns the length of the data payload in bytes.
-    pub fn data_length(&self) -> c_ushort {
+    pub fn data_length(&self) -> c_uint {
         self.ptr().datalength
     }
 
@@ -364,8 +364,8 @@ impl MSRecord {
         })
     }
 
-    /// Returns the size of the (unpacked) data samples in bytes.
-    pub fn data_size(&self) -> usize {
+    /// Returns the size of the buffer for (unpacked) data samples in bytes.
+    pub fn data_size(&self) -> c_ulong {
         self.ptr().datasize
     }
 

--- a/src/trace.rs
+++ b/src/trace.rs
@@ -1,4 +1,4 @@
-use std::ffi::{c_double, c_float, c_int, c_long, c_uchar, c_uint};
+use std::ffi::{c_double, c_float, c_int, c_long, c_ulong, c_uchar, c_uint};
 use std::fmt;
 use std::ptr;
 use std::slice::from_raw_parts;
@@ -144,8 +144,8 @@ impl<'id> MSTraceSegment<'id> {
         Ok(rv)
     }
 
-    /// Returns the size of the (unpacked) data samples in bytes.
-    pub fn data_size(&self) -> usize {
+    /// Returns the size of the buffer for (unpacked) data samples in bytes.
+    pub fn data_size(&self) -> c_ulong {
         self.ptr().datasize
     }
 


### PR DESCRIPTION
I broke the cardinal rule and changed the API of libmseed.  In partial penance, here is a pull request fixing these mismatches with the current release (I hope!).  I expect (edit) v3.1.0 to be stable from here on out.

I did not really understand how libmseed was "fetched" or "included" in this code base so it may need some fixing.

To explain the changes: the `MS3Record.datalength` value changed from `uint16` to `uint32` to match the approved specification.  This value was not properly updated when the specification was changed later in the review process.
This stinks but is unavoidable because the specification must be accommodated by the library.

While the API was now broken, I took the opportunity to fix and improve a couple of other API things in the latest release.


While I was in this code I noticed a couple of other things that may be of interest:

* The tests include assertions for the `datasize` value.  This value is not the exact data size for the unpacked data, but the size of the allocated buffer.  This value will be different on Windows versus non-Windows because libmseed will pre-allocate (allocating more than needed) on Windows for performance.  I recommend dropping those assertions.

* The wrapper code uses the std::ffi::c_* types.  But the library uses mostly fixed-width integers.  Perhaps I do not understand this part of rust. The std::ffi::c_long is documented as `pub type c_long = i64;` but described as: "This type will always be i32 or i64", which is true in C and exactly why libmseed does _not_ use those types when the size is important. Would it not be better to match the library types that are exact, like u16, u32, i64, u64?