### PR TITLE
Update to libmseed version `3.1.1`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mseed"
-version = "0.6.0"
+version = "0.7.0"
 authors = ["Daniel Armbruster <dani.armbruster@gmail.com>"]
 license = "Apache-2.0"
 readme = "README.md"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-libmseed-sys = { path = "libmseed-sys", version="0.2.1"}
+libmseed-sys = { path = "libmseed-sys", version="0.3.0"}
 
 bitflags = "2.4.0"
 num-traits = "0.2"

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ modify `Cargo.toml`:
 
 ```toml
 [dependencies]
-mseed = "0.6"
+mseed = "0.7"
 ```
 
 ## Documentation

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ cargo build
 
 ## Version of libmseed
 
-Currently this library requires `libmseed` version 3.0.17 (or newer patch
+Currently this library requires `libmseed` version 3.1.1 (or newer patch
 versions). The source for `libmseed` is included in the `libmseed-sys` crate so
 there's no need to pre-install the `libmseed` library, the `libmseed-sys` crate
 will figure that and/or build that for you.

--- a/README.md
+++ b/README.md
@@ -48,4 +48,3 @@ Any PR is very welcomed!
 
 Licensed under the [Apache-2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
 For more information see the [LICENSE](/LICENSE) file.
-

--- a/libmseed-sys/Cargo.toml
+++ b/libmseed-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libmseed-sys"
-version = "0.2.1+3.0.19"
+version = "0.3.0+3.1.1"
 authors = ["Daniel Armbruster <dani.armbruster@gmail.com>, Brian Savage <savage13@gmail.com>"]
 links = "mseed"
 build = "build.rs"

--- a/libmseed-sys/Cargo.toml
+++ b/libmseed-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libmseed-sys"
-version = "0.2.1+3.0.17"
+version = "0.2.1+3.0.19"
 authors = ["Daniel Armbruster <dani.armbruster@gmail.com>, Brian Savage <savage13@gmail.com>"]
 links = "mseed"
 build = "build.rs"

--- a/libmseed-sys/Cargo.toml
+++ b/libmseed-sys/Cargo.toml
@@ -24,6 +24,6 @@ path = "lib.rs"
 [dependencies]
 
 [build-dependencies]
-bindgen = "0.66.1"
+bindgen = "0.69"
 cc = { version = "1.0", features = ["parallel"] }
 

--- a/libmseed-sys/build.rs
+++ b/libmseed-sys/build.rs
@@ -3,8 +3,6 @@ extern crate bindgen;
 use std::env;
 use std::path::PathBuf;
 
-use bindgen::CargoCallbacks;
-
 const LIB_DIR: &str = "vendor";
 const SOURCE_FILES: [&str; 17] = [
     "crc32c.c",
@@ -62,7 +60,7 @@ fn main() {
 
     let bindings = bindgen::Builder::default()
         .header(headers_path_str)
-        .parse_callbacks(Box::new(CargoCallbacks))
+        .parse_callbacks(Box::new(bindgen::CargoCallbacks::new()))
         .clang_arg(&format!("-I{}", lib_dir_path_str))
         .allowlist_type("MS.*")
         .allowlist_var("MS_.*")

--- a/libmseed-sys/lib.rs
+++ b/libmseed-sys/lib.rs
@@ -37,7 +37,7 @@ mod tests {
         assert_eq!(sid, "FDSN:IU_ANMO_00_B_H_Z");
         assert_eq!(ms.starttime, 1267252200019538000);
         assert_eq!(ms.samprate, 20.0);
-        assert_eq!(ms.encoding, DE_STEIM2 as i8);
+        assert_eq!(ms.encoding, DE_STEIM2 as i16);
         assert_eq!(ms.pubversion, 4);
         assert_eq!(ms.samplecnt, 419);
         assert_eq!(ms.crc, 0);
@@ -66,7 +66,7 @@ mod tests {
         assert_eq!(sid, "FDSN:IU_ANMO_00_B_H_Z");
         assert_eq!(ms.starttime, 1267252220969538000);
         assert_eq!(ms.samprate, 20.0);
-        assert_eq!(ms.encoding, DE_STEIM2 as i8);
+        assert_eq!(ms.encoding, DE_STEIM2 as i16);
         assert_eq!(ms.pubversion, 4);
         assert_eq!(ms.samplecnt, 368);
         assert_eq!(ms.crc, 0);

--- a/src/io.rs
+++ b/src/io.rs
@@ -1,4 +1,4 @@
-use std::ffi::{c_char, c_int, c_long, c_void, CString};
+use std::ffi::{c_char, c_int, c_void, CString};
 use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::ptr;
@@ -233,7 +233,7 @@ impl<W: Write> MSWriter<W> {
     ///  case of miniSEED 2, unfilled.
     ///  If `flags` has [`MSControlFlags::MSF_PACKVER2`] set `msr` is packed as miniSEED v2
     ///  regardless of msr's [`MSRecord::format_version`].
-    pub fn write_record(&mut self, msr: &MSRecord, flags: MSControlFlags) -> MSResult<c_long> {
+    pub fn write_record(&mut self, msr: &MSRecord, flags: MSControlFlags) -> MSResult<c_int> {
         // XXX(damb): reimplementation of [`raw::msr3_writemseed`]
         unsafe {
             check(raw::msr3_pack(
@@ -243,7 +243,7 @@ impl<W: Write> MSWriter<W> {
                 ptr::null_mut(),
                 flags.bits(),
                 0,
-            ) as c_long)
+            ) as c_int)
         }
     }
 
@@ -254,7 +254,7 @@ impl<W: Write> MSWriter<W> {
         flags: MSControlFlags,
         encoding: MSDataEncoding,
         max_rec_len: c_int,
-    ) -> MSResult<c_long> {
+    ) -> MSResult<i64> {
         // XXX(damb): reimplementation of [`raw::mstl3_writemseed`]
         let mut flags = flags;
         flags |= MSControlFlags::MSF_MAINTAINMSTL;
@@ -271,7 +271,7 @@ impl<W: Write> MSWriter<W> {
                 flags.bits(),
                 0,
                 ptr::null_mut(),
-            ) as c_long)
+            ) as i64)
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,8 +80,6 @@
 //! .unwrap();
 //! ```
 
-use std::ffi::c_uint;
-
 use bitflags::bitflags;
 
 use libmseed_sys as raw;
@@ -138,7 +136,7 @@ pub enum MSErrorCode {
 bitflags! {
     /// Parsing, packing and trace construction control flags.
     #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-    pub struct MSControlFlags: c_uint {
+    pub struct MSControlFlags: u32 {
         /// **Parsing**: Unpack data samples.
         const MSF_UNPACKDATA = raw::MSF_UNPACKDATA;
         /// **Parsing**: Skip input that cannot be identified as miniSEED.

--- a/src/pack.rs
+++ b/src/pack.rs
@@ -1,4 +1,4 @@
-use std::ffi::{c_char, c_double, c_int, c_long, c_uchar, c_uint, c_ushort, c_void, CString};
+use std::ffi::{c_char, c_double, c_int, c_long, c_ulong, c_uchar, c_uint, c_ushort, c_void, CString};
 use std::mem;
 use std::ptr;
 use std::slice;
@@ -320,7 +320,7 @@ where
             .map_err(|e| MSError::from_str(&format!("invalid data sample length ({})", e)))?
             as _;
         (*msr).datasamples = data_samples.as_mut_ptr() as *mut _ as *mut c_void;
-        (*msr).datasize = mem::size_of_val(data_samples);
+        (*msr).datasize = mem::size_of_val(data_samples) as c_ulong;
         (*msr).extralength = 0;
         (*msr).extra = ptr::null_mut();
     }

--- a/src/record.rs
+++ b/src/record.rs
@@ -1,4 +1,4 @@
-use std::ffi::{c_char, c_double, c_long, c_ulong,c_uchar, c_uint, CStr};
+use std::ffi::{c_char, c_double, c_long, c_uchar, c_uint, CStr};
 use std::fmt;
 use std::ptr;
 use std::slice::from_raw_parts;
@@ -18,7 +18,7 @@ pub struct RecordDetection {
     /// Major version of the format detected.
     pub format_version: c_uchar,
     /// Size of the record in bytes. `None` if the record length is unknown.
-    pub rec_len: Option<usize>,
+    pub rec_len: Option<u64>,
 }
 
 /// Detect miniSEED record in buffer.
@@ -41,7 +41,7 @@ pub fn detect<T: AsRef<[u8]>>(buf: T) -> MSResult<RecordDetection> {
     let rec_len = if rec_len == 0 {
         None
     } else {
-        Some(rec_len as usize)
+        Some(rec_len as u64)
     };
 
     Ok(RecordDetection {
@@ -365,7 +365,7 @@ impl MSRecord {
     }
 
     /// Returns the size of the buffer for (unpacked) data samples in bytes.
-    pub fn data_size(&self) -> c_ulong {
+    pub fn data_size(&self) -> u64 {
         self.ptr().datasize
     }
 

--- a/src/record.rs
+++ b/src/record.rs
@@ -1,4 +1,4 @@
-use std::ffi::{c_char, c_double, c_long, c_uchar, c_uint, c_ushort, CStr};
+use std::ffi::{c_char, c_double, c_long, c_ulong,c_uchar, c_uint, CStr};
 use std::fmt;
 use std::ptr;
 use std::slice::from_raw_parts;
@@ -331,7 +331,7 @@ impl MSRecord {
     }
 
     /// Returns the length of the data payload in bytes.
-    pub fn data_length(&self) -> c_ushort {
+    pub fn data_length(&self) -> c_uint {
         self.ptr().datalength
     }
 
@@ -364,8 +364,8 @@ impl MSRecord {
         })
     }
 
-    /// Returns the size of the (unpacked) data samples in bytes.
-    pub fn data_size(&self) -> usize {
+    /// Returns the size of the buffer for (unpacked) data samples in bytes.
+    pub fn data_size(&self) -> c_ulong {
         self.ptr().datasize
     }
 

--- a/src/record.rs
+++ b/src/record.rs
@@ -80,35 +80,35 @@ impl MSSampleType {
 }
 
 /// An enumeration of possible data encodings.
-#[repr(u8)]
+#[repr(i16)]
 #[derive(Debug, Eq, PartialEq, Copy, Clone)]
 pub enum MSDataEncoding {
     /// Text encoding (UTF-8)
-    Text = raw::DE_TEXT as u8,
+    Text = raw::DE_TEXT as i16,
     /// 16-bit integer encoding
-    Integer16 = raw::DE_INT16 as u8,
+    Integer16 = raw::DE_INT16 as i16,
     /// 32-bit integer encoding
-    Integer32 = raw::DE_INT32 as u8,
+    Integer32 = raw::DE_INT32 as i16,
     /// 32-bit floating point encoding (IEEE)
-    Float32 = raw::DE_FLOAT32 as u8,
+    Float32 = raw::DE_FLOAT32 as i16,
     /// 64-bit floating point encoding (IEEE)
-    Float64 = raw::DE_FLOAT64 as u8,
+    Float64 = raw::DE_FLOAT64 as i16,
     /// Steim-1 compressed integer encoding
-    Steim1 = raw::DE_STEIM1 as u8,
+    Steim1 = raw::DE_STEIM1 as i16,
     /// Steim-2 compressed integer encoding
-    Steim2 = raw::DE_STEIM2 as u8,
+    Steim2 = raw::DE_STEIM2 as i16,
     /// **Legacy**: GEOSCOPE 24-bit integer encoding
-    GeoScope24 = raw::DE_GEOSCOPE24 as u8,
+    GeoScope24 = raw::DE_GEOSCOPE24 as i16,
     /// **Legacy**: GEOSCOPE 16-bit gain ranged, 3-bit exponent
-    GeoScope163 = raw::DE_GEOSCOPE163 as u8,
+    GeoScope163 = raw::DE_GEOSCOPE163 as i16,
     /// **Legacy**: GEOSCOPE 16-bit gain ranged, 4-bit exponent
-    GeoScope164 = raw::DE_GEOSCOPE164 as u8,
+    GeoScope164 = raw::DE_GEOSCOPE164 as i16,
     /// **Legacy**: CDSN 16-bit gain ranged
-    CDSN = raw::DE_CDSN as u8,
+    CDSN = raw::DE_CDSN as i16,
     /// **Legacy**: SRO 16-bit gain ranged
-    SRO = raw::DE_SRO as u8,
+    SRO = raw::DE_SRO as i16,
     /// **Legacy**: DWWSSN 16-bit gain ranged
-    DWWSSN = raw::DE_DWWSSN as u8,
+    DWWSSN = raw::DE_DWWSSN as i16,
 }
 
 impl MSDataEncoding {
@@ -140,7 +140,7 @@ impl fmt::Display for MSDataEncoding {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         unsafe {
             let encoding = CStr::from_ptr(raw::ms_encodingstr(
-                (*self as c_char)
+                (*self as u8)
                     .try_into()
                     .map_err(|_| fmt::Error)
                     .unwrap(),

--- a/src/record.rs
+++ b/src/record.rs
@@ -696,7 +696,12 @@ mod tests {
         }
 
         assert_eq!(msr.data_length(), 384);
-        assert_eq!(msr.data_size(), 540);
+        // XXX(damb): size of allocated buffer. This value will be different on Windows versus
+        // non-Windows because libmseed will pre-allocate (allocating more than needed) on Windows
+        // for performance. Credits to Chad
+        // (https://github.com/damb/mseed/pull/15#issue-2097164022).
+        // 
+        // assert_eq!(msr.data_size(), 540);
         assert_eq!(msr.num_samples(), 135);
 
         assert_eq!(msr.sample_type(), MSSampleType::Integer32);
@@ -761,7 +766,12 @@ mod tests {
         }
 
         assert_eq!(msr.data_length(), 448);
-        assert_eq!(msr.data_size(), 540);
+        // XXX(damb): size of allocated buffer. This value will be different on Windows versus
+        // non-Windows because libmseed will pre-allocate (allocating more than needed) on Windows
+        // for performance. Credits to Chad
+        // (https://github.com/damb/mseed/pull/15#issue-2097164022).
+        // 
+        // assert_eq!(msr.data_size(), 540);
         assert_eq!(msr.num_samples(), 135);
 
         assert_eq!(msr.sample_type(), MSSampleType::Integer32);

--- a/src/record.rs
+++ b/src/record.rs
@@ -700,7 +700,7 @@ mod tests {
         // non-Windows because libmseed will pre-allocate (allocating more than needed) on Windows
         // for performance. Credits to Chad
         // (https://github.com/damb/mseed/pull/15#issue-2097164022).
-        // 
+        //
         // assert_eq!(msr.data_size(), 540);
         assert_eq!(msr.num_samples(), 135);
 
@@ -770,7 +770,7 @@ mod tests {
         // non-Windows because libmseed will pre-allocate (allocating more than needed) on Windows
         // for performance. Credits to Chad
         // (https://github.com/damb/mseed/pull/15#issue-2097164022).
-        // 
+        //
         // assert_eq!(msr.data_size(), 540);
         assert_eq!(msr.num_samples(), 135);
 

--- a/src/trace.rs
+++ b/src/trace.rs
@@ -1,4 +1,4 @@
-use std::ffi::{c_double, c_float, c_int, c_long, c_uchar, c_uint};
+use std::ffi::{c_double, c_float, c_int, c_long, c_ulong, c_uchar, c_uint};
 use std::fmt;
 use std::ptr;
 use std::slice::from_raw_parts;
@@ -144,8 +144,8 @@ impl<'id> MSTraceSegment<'id> {
         Ok(rv)
     }
 
-    /// Returns the size of the (unpacked) data samples in bytes.
-    pub fn data_size(&self) -> usize {
+    /// Returns the size of the buffer for (unpacked) data samples in bytes.
+    pub fn data_size(&self) -> c_ulong {
         self.ptr().datasize
     }
 

--- a/src/trace.rs
+++ b/src/trace.rs
@@ -1,4 +1,4 @@
-use std::ffi::{c_double, c_float, c_int, c_long, c_ulong, c_uchar, c_uint};
+use std::ffi::c_double;
 use std::fmt;
 use std::ptr;
 use std::slice::from_raw_parts;
@@ -37,7 +37,7 @@ impl MSTraceId {
     }
 
     /// Returns the largest contributing publication version.
-    pub fn pub_version(&self) -> c_uchar {
+    pub fn pub_version(&self) -> u8 {
         self.ptr().pubversion
     }
 
@@ -52,7 +52,7 @@ impl MSTraceId {
     }
 
     /// Returns the number of [`MSTraceSegment`]s for this trace identifier.
-    pub fn len(&self) -> c_uint {
+    pub fn len(&self) -> u32 {
         self.ptr().numsegments
     }
 
@@ -120,7 +120,7 @@ impl<'id> MSTraceSegment<'id> {
     }
 
     /// Returns the number of samples in trace coverage.
-    pub fn sample_cnt(&self) -> c_long {
+    pub fn sample_cnt(&self) -> i64 {
         self.ptr().samplecnt as _
     }
 
@@ -145,12 +145,12 @@ impl<'id> MSTraceSegment<'id> {
     }
 
     /// Returns the size of the buffer for (unpacked) data samples in bytes.
-    pub fn data_size(&self) -> c_ulong {
+    pub fn data_size(&self) -> u64 {
         self.ptr().datasize
     }
 
     /// Returns the number of (unpacked) data samples.
-    pub fn num_samples(&self) -> c_long {
+    pub fn num_samples(&self) -> i64 {
         self.ptr().numsamples as _
     }
 
@@ -197,13 +197,13 @@ pub trait DataSampleType {
     unsafe fn convert_into(seg: *mut MS3TraceSeg, truncate: bool) -> MSResult<()>;
 }
 
-impl DataSampleType for c_uchar {
+impl DataSampleType for u8 {
     unsafe fn convert_into(_seg: *mut MS3TraceSeg, _truncate: bool) -> MSResult<()> {
         Ok(())
     }
 }
 
-impl DataSampleType for c_int {
+impl DataSampleType for i32 {
     unsafe fn convert_into(seg: *mut MS3TraceSeg, truncate: bool) -> MSResult<()> {
         let rv = unsafe {
             check(raw::mstl3_convertsamples(
@@ -220,7 +220,7 @@ impl DataSampleType for c_int {
     }
 }
 
-impl DataSampleType for c_float {
+impl DataSampleType for f32 {
     unsafe fn convert_into(seg: *mut MS3TraceSeg, truncate: bool) -> MSResult<()> {
         let rv = unsafe {
             check(raw::mstl3_convertsamples(
@@ -237,7 +237,7 @@ impl DataSampleType for c_float {
     }
 }
 
-impl DataSampleType for c_double {
+impl DataSampleType for f64 {
     unsafe fn convert_into(seg: *mut MS3TraceSeg, truncate: bool) -> MSResult<()> {
         let rv = unsafe {
             check(raw::mstl3_convertsamples(
@@ -402,7 +402,7 @@ impl MSTraceList {
     }
 
     /// Returns the length of the trace list.
-    pub fn len(&self) -> c_uint {
+    pub fn len(&self) -> u32 {
         self.ptr().numtraceids
     }
 


### PR DESCRIPTION
This PR contains several API changes!

**Feature and Changes**:

 - Bump libmseed version to 3.1.1 and adopt to libmseed API changes
 - Use fixed-width types where size matters

This PR supersedes #15.